### PR TITLE
Replace tab with a single space after WWW: in pkg-descr

### DIFF
--- a/tmpl/common/pkg-descr.tmpl
+++ b/tmpl/common/pkg-descr.tmpl
@@ -1,3 +1,3 @@
 [description of the port]
 
-WWW:	%%WWW%%
+WWW: %%WWW%%


### PR DESCRIPTION
To fix portlint WARNING "pkg-descr: use WWW: with a single space, then http://example.com",
replace tab with a single space after WWW: in pkg-descr.
