### PR TITLE
rubygem: USES must appear before USE_*

### DIFF
--- a/tmpl/rubygem/Makefile.tmpl
+++ b/tmpl/rubygem/Makefile.tmpl
@@ -11,7 +11,7 @@ COMMENT=
 LICENSE=	
 LICENSE_FILE=	
 
-USE_RUBY=	yes
 USES=		gem
+USE_RUBY=	yes
 
 .include <bsd.port.mk>


### PR DESCRIPTION
portlint warns like this:
>    WARN: Makefile: [14]: USE_* seen before USES.  According to the
>    porters-handbook, USES must appear first.