### PR TITLE
Switch to use Git

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Introduction
 
 FreeBSD Port Tools consist of the several small scripts run from
 `port(1)` front-end:
-- `port commit`: commit a port into the FreeBSD Ports SVN Repository
+- `port commit`: commit a port into the FreeBSD Ports GIT Repository
 - `port create`: create a new port from a template
 - `port diff`: generate a diff against a previous version of the port
 - `port fetch`: fetch distfile(s) of a new version of the port
@@ -28,27 +28,23 @@ Usage
 Let us assume you are interested in helping out with one of the ports.
 The most convenient way of doing that with the Port Tools is the following.
 Even though the Port Tools have 3 most of diff generation, the recommended is
-SVN (default). Do not be scared away at this point - it is very simple.
+GIT (default). Do not be scared away at this point - it is very simple.
 Let me give a quick overview:
 
 1. Check out a working copy of the port. I usually do it in `~/ports` directory:
-   (NOTE: my `~/ports` directory contains only those ports I am interested in,
-   i.e. either maitain or send changes/updates to. Thus, it does not have
-   to contain the whole FreeBSD Ports tree)
 
 ```
-   xmj@mx12:~% cd ~/ports
-   xmj@mx12:~/ports% svn co ipsvd
+   xmj@mx12:~% git clone https://git.freebsd.org/ports.git
+   xmj@mx12:~% cd ~/ports/net/ipsvd
 ```
 
-   `ipsvd` is the sample port name.
+   `net/ipsvd` is the sample port name.
 
 2. Now, make your changes - e.g. change PORTVERSION from `0.6.0` to `0.6.1`.
 
 
 ```
-   xmj@mx12:~/ports/ipsvd% cd ipsvd
-   xmj@mx12:~/ports/ipsvd% vim Makefile
+   xmj@mx12:~/ports/net/ipsvd% vim Makefile
 ```
 
 3. At this moment we need to fetch the new distfile and run `make makesum`
@@ -56,20 +52,20 @@ Let me give a quick overview:
    with the Port Tools version `0.50` or later:
 
 ```
-   xmj@mx12:~/ports/ipsvd% port fetch
+   xmj@mx12:~/ports/net/ipsvd% port fetch
 ```
 
 4. Now we want to make sure that the port compiles, installs and works fine:
 
 ```
-   xmj@mx12:~/ports/ipsvd% port test
+   xmj@mx12:~/ports/net/ipsvd% port test
 ```
 
 5. Once I am satisfied with the results, let us submit a PR
    with the port update:
 
 ```
-   xmj@mx12:~/ports/ipsvd% port submit
+   xmj@mx12:~/ports/net/ipsvd% port submit
 ```
 
 6. Sometimes things need work after submitting. Here's where I use followup to

--- a/man/port.1
+++ b/man/port.1
@@ -97,7 +97,7 @@ Generated file then passed to the viewer specified in
 .Pa ~/.porttools
 configuration file.
 Default viewer is
-.Xr cdiff 1
+.Xr ydiff 1
 if present,
 otherwise -
 .Xr more 1 .
@@ -116,8 +116,8 @@ display usage summary for this command.
 .It Fl d Ar mode
 select diff generation mode:
 .Bl -tag -width ".Pa suffix"
-.It SVN
-diff against SVN repository (default).
+.It GIT
+diff against GIT repository (default).
 .It Pa dir
 diff against original version of the port in the Ports tree with root at
 .Pa dir
@@ -138,10 +138,10 @@ generate SHAR as if the port was new
 .Pp
 Example:
 .Pp
-.Dl % port diff -d SVN
+.Dl % port diff -d GIT
 .Pp
 This would generate unified diff of modified checked-out working copy
-of the port against SVN repo.
+of the port against GIT repo.
 .It Ar fetch
 Fetch one or more distfiles of new or updated port version
 and updates checksums.
@@ -350,8 +350,8 @@ See
 for detailed description of the format.
 .El
 .Sh SEE ALSO
-.Xr svn 1 ,
-.Xr cdiff 1 ,
+.Xr git 1 ,
+.Xr ydiff 1 ,
 .Xr diff 1 ,
 .Xr more 1 ,
 .Xr portlint 1 ,

--- a/man/porttools.5
+++ b/man/porttools.5
@@ -53,7 +53,7 @@ Directory where PREFIX and PKG_DBDIR subdirectories will be created.
 Default to
 .Pa /tmp .
 .It Ev DIFF_MODE
-Selects diff generation mode. Valid values are: SVN, directory
+Selects diff generation mode. Valid values are: GIT, directory
 .Pq e.g. Pa /usr/ports ,
 or suffix
 .Pq e.g. Pa .orig .
@@ -64,7 +64,7 @@ and
 .Xr shar 1
 files.
 Default to
-.Xr cdiff 1
+.Xr ydiff 1
 if present in the ${PATH},
 with a fallback to
 .Xr more 1 .
@@ -72,7 +72,7 @@ with a fallback to
 .Pp
 FreeBSD Port Tools configuration file is generated automatically if missing.
 .Sh SEE ALSO
-.Xr cdiff 1 ,
+.Xr ydiff 1 ,
 .Xr diff 1 ,
 .Xr port 1 ,
 .Xr shar 1 .

--- a/scripts/cmd_commit.in
+++ b/scripts/cmd_commit.in
@@ -1,6 +1,6 @@
 # cmd_commit
 # Module for port(1)
-# SUMMARY: commit a port into the FreeBSD Ports SVN Repository
+# SUMMARY: commit a port into the FreeBSD Ports GIT Repository
 
 # Check if this script is run via port(1)
 if [ "${PORTTOOLS}" = "" ]
@@ -56,7 +56,7 @@ echo "===> Your username on freefall: ${FREEFALL_USERNAME}"
 
 # Determine if this is a new port
 MODE="update"
-svn status Makefile 2>&1 1>/dev/null | grep -qs 'svn: warning: W155007:'
+git status Makefile 2>&1 | grep -qs 'fatal: not a git repository'
 if [ $? -eq 0 ]
 then
 	MODE="new"
@@ -75,7 +75,7 @@ then
 fi
 
 
-# See if SVN message already exists, and use that for commit log
+# See if GIT message already exists, and use that for commit log
 MSG="svn-msg"
 FLAGS=""
 
@@ -90,10 +90,6 @@ then
 
 	${PORTSDIR}/Tools/scripts/addport -d `pwd` -u ${FREEFALL_USERNAME} ${FLAGS}
 else
-	# Make sure we are working with up-to-date version
-	echo "===> Pre-commit SVN update"
-	svn update
-
 	if [ -e ${MSG} ]
 	then
 		FLAGS="-F ${MSG}"
@@ -104,17 +100,17 @@ else
 			echo '============================================='
 			cat ${MSG}
 			echo '============================================='
-			read -p "Is the SVN message above correct? (y/n)" ANSWER
+			read -p "Is the GIT message above correct? (y/n)" ANSWER
 			[ "${ANSWER}" = "y" ] && break
 			${VISUAL:-vi} ${MSG}
 		done
 	fi
 	# Commit the port update
 	echo "===> Committing port update"
-	svn commit ${FLAGS}
+	git commit ${FLAGS}
 
 fi
-# Remove SVN message file only if commit was successful
+# Remove GIT message file only if commit was successful
 [ $? -eq 0 -a -e ${MSG} ] && rm ${MSG}
 
 echo "===> Done"

--- a/scripts/cmd_diff.in
+++ b/scripts/cmd_diff.in
@@ -17,7 +17,6 @@ FreeBSD Port Tools __VERSION__
 Usage: port diff [-h] [-d <diff mode>]
 	-h	- Display this usage summary
 	-d <diff mode> - Select diff generation mode:
-		SVN - against SVN
 		GIT - against git
 		<dir> - against Ports tree in <dir>
 		<pattern> - against original port in <pwd><pattern>
@@ -66,7 +65,7 @@ done
 # View patch using specified viewer
 if [ "${DIFF_VIEWER}" = "" ]
 then
-	DIFF_VIEWER=`which cdiff`
+	DIFF_VIEWER=`which ydiff`
 	[ -n "${DIFF_VIEWER}" ] || DIFF_VIEWER="more"
 fi
 echo "===> Viewing diff with ${DIFF_VIEWER}"

--- a/scripts/cmd_submit.in
+++ b/scripts/cmd_submit.in
@@ -26,7 +26,6 @@ Usage:	port submit [-h] [-m <mode>] [-d <diff mode>]
 		change - changing a port
 		update - updating a port to newer version
 	-d <diff mode> - Select diff generation mode:
-		SVN - against SVN
 		GIT - against git
 		<dir> - against Ports tree in <dir>
 		<pattern> - against original port in <pwd><pattern>
@@ -131,13 +130,13 @@ done
 # Determine if this is a new port
 if [ "${MODE}" = "" ]
 then
-	svn status Makefile 2>&1 1>/dev/null | grep -qs 'svn: warning: W155007:'
+	git status Makefile 2>&1 | grep -qs 'fatal: not a git repository'
 	[ $? -eq 0 ] || [ "`grep '\$FreeBSD: ' Makefile`" ] || MODE="new"
 fi
 
 # util_diff will set
 # - PORTBASENAME if PORTNAME != port's directory name
-# - DIFF_TYPE to SVN, GIT, ports, or suffix
+# - DIFF_TYPE to GIT, ports, or suffix
 PORTBASENAME=""
 DIFF_TYPE=""
 

--- a/scripts/port.in
+++ b/scripts/port.in
@@ -18,7 +18,7 @@ then
 	CC=""
 	BUILDROOT="/tmp"
 	ARCHIVE_DIR=""
-	DIFF_MODE="SVN"
+	DIFF_MODE="GIT"
 	DIFF_VIEWER="more"
 	PORTLINT_FLAGS="abct"
 	PORTSDIR="/usr/ports"

--- a/scripts/util_diff.in
+++ b/scripts/util_diff.in
@@ -11,8 +11,8 @@ fi
 # Determine if this is a new port
 if [ "${MODE}" = "" ]
 then
-	svn status Makefile 2>&1 1>/dev/null | grep -qs 'svn: warning: W155007:'
-	[ $? -eq 0 ] || [ "`grep '\$FreeBSD: ' Makefile`" ] || MODE="new"
+	git status Makefile 2>&1 | grep -qs 'fatal: not a git repository'
+	[ $? -eq 0 ] || [ "`grep '\$FreeBSD' Makefile`" ] || MODE="new"
 fi
 
 # Create a temporary dir for generated files (patch/shar, PR form)
@@ -68,42 +68,15 @@ else
 	# Determine the default diff mode
 	if [ "${DIFF_MODE}" = "" ]
 	then
-		svn info > /dev/null 2>&1
+		git status > /dev/null 2>&1
 		status=$?
-		if [ $status -eq 0 ];
+		if [ $status -eq 0 ]
 		then
-			DIFF_MODE="SVN"
+			DIFF_MODE="GIT"
 		else
-			git status > /dev/null 2>&1
-			status=$?
-			if [ $status -eq 0 ]
-			then
-				DIFF_MODE="GIT"
-			else
-				DIFF_MODE="${PORTSDIR}"
-			fi
+			DIFF_MODE="${PORTSDIR}"
 		fi
 		echo "Default diff mode is ${DIFF_MODE}"
-	elif [ "${DIFF_MODE}" = "SVN" ]
-	then
-		# If `pwd` is not a svn working copy
-		# fallback to diffing against ${PORTSDIR} tree
-		svn info > /dev/null 2>&1
-		status=$?
-		if [ $status -ne 0 ]
-		then
-			echo "Diff mode was set to ${DIFF_MODE}, but `pwd` is not a svn working copy."
-			echo -n "Trying ${PORTSDIR} ... "
-			if [ -d ${PORTSDIR} ]
-			then
-				DIFF_MODE="${PORTSDIR}"
-				echo "found"
-			else
-				echo "not found - please choose an approriate diff mode"
-				cleanup
-				exit 1
-			fi
-		fi
 	elif [ "${DIFF_MODE}" = "GIT" ]
 	then
 		# If `pwd` is not a git working copy
@@ -133,38 +106,12 @@ else
 	PKGNAMESUFFIX="`make -V PKGNAMESUFFIX`"
 	PORTNAME="${PKGNAMEPREFIX}`make -V PORTNAME`${PKGNAMESUFFIX}"
 
-	if [ "${DIFF_MODE}" = "SVN" ]
+	if [ "${DIFF_MODE}" = "GIT" ]
 	then
 		DIFF_TYPE=${DIFF_MODE}
-
-		# Run 'svn update' first
-		echo "===> Updating from SVN"
-		svn update
-		status=$?
-		if [ $status -ne 0 ]
-		then
-			echo "Error updating SVN"
-			cleanup
-			exit 1
-		fi
-		DIFF_CMD="svn diff"
-	elif [ "${DIFF_MODE}" = "GIT" ]
-	then
-		DIFF_TYPE=${DIFF_MODE}
-
-		# Run 'git pull' first
-		echo "===> Updating from git"
-		git pull
-		status=$?
-		if [ $status -ne 0 ]
-		then
-			echo "Error updating git"
-			cleanup
-			exit 1
-		fi
 		DIFF_CMD="git diff"
 	else
-		# Non-SVN modes
+		# Non-GIT modes
 		# FIXME: these two checks should really exist for all VCS
 		DIRBASENAME=`basename \`pwd\``
 		PORTBASENAME_HEADER=`sed -n -E -e '1,/^($|[^#].*$)|\\$FreeBSD\:/s%^#.*\\$FreeBSD\:[[:space:]]*([^/]+/)*([^/]+)/Makefile.*\\$%\2%p' Makefile`


### PR DESCRIPTION
Switch to used Git since FreeBSD ports repository has migrated from Subversion to Git.

Notes:
- `SVN` mode of `diff` command is removed and default is switched to `GIT`. User may need to edit his `~/.porttool`.
- `diff` command now uses `ydiff` as default diff viewer.
- Currently `new` mode of `commit` command doesn't work because `${PORTSDIR}/Tools/scripts/addport` doesn't support Git yet.
- `commit` command commits changes to not FreeBSD ports repository but local clone of it.
- Though some changes related to Git are made, `submit` command is still broken.